### PR TITLE
feat: Introduce `releaseFull` command for automated releases

### DIFF
--- a/cli.json
+++ b/cli.json
@@ -175,11 +175,49 @@
         "metaInfo": {
           "hasValue": true,
           "description": "Meta information for publishing"
+        },
+        "packageVersion": {
+          "hasValue": true
         }
       }
     },
     "release": {
       "description": "Push builded file to server."
+    },
+    "releaseFull": {
+      "options": {
+        "origin": {
+          "hasValue": true
+        },
+        "next": {
+          "hasValue": true
+        },
+        "output": {
+          "hasValue": true,
+          "default": "${tempDir}/output/diff-${time}.ppk-patch"
+        },
+        "platform": {
+          "hasValue": true
+        },
+        "name": {
+          "hasValue": true
+        },
+        "description": {
+          "hasValue": true
+        },
+        "packageVersion": {
+          "hasValue": true
+        },
+        "metaInfo": {
+          "hasValue": true
+        },
+        "rollout": {
+          "hasValue": true
+        },
+        "dryRun": {
+          "default": false
+        }
+      }
     },
     "diff": {
       "description": "Create diff patch",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -548,8 +548,18 @@ function basename(fn: string) {
   return m?.[1];
 }
 
-async function diffFromPPK(origin: string, next: string, output: string) {
+async function diffFromPPKInternal(origin: string, next: string, output: string, diffAlgorithm?: Diff) {
   fs.ensureDirSync(path.dirname(output));
+
+  const selectedDiff = diffAlgorithm || diff; // Use provided algorithm or global 'diff'
+
+  if (!selectedDiff && !bsdiff) {
+    throw new Error(
+      `Diff algorithm not specified and bsdiff is not available. Please install "node-bsdiff".`,
+    );
+  }
+  const currentDiffTool = selectedDiff || bsdiff; // Default to bsdiff if global 'diff' is not set
+
 
   const originEntries = {};
   const originMap = {};
@@ -620,7 +630,7 @@ async function diffFromPPK(origin: string, next: string, output: string) {
       return readEntry(entry, nextZipfile).then((newSource) => {
         //console.log('Begin diff');
         zipfile.addBuffer(
-          diff(originSource, newSource),
+          currentDiffTool(originSource, newSource),
           'index.bundlejs.patch',
         );
         //console.log('End diff');
@@ -630,7 +640,7 @@ async function diffFromPPK(origin: string, next: string, output: string) {
       return readEntry(entry, nextZipfile).then((newSource) => {
         //console.log('Begin diff');
         zipfile.addBuffer(
-          diff(originSource, newSource),
+          currentDiffTool(originSource, newSource),
           'bundle.harmony.js.patch',
         );
         //console.log('End diff');
@@ -900,9 +910,29 @@ function diffArgsCheck(args: string[], options: any, diffFn: string) {
   };
 }
 
+export async function diffFromPPK(origin: string, next: string, output: string, diffAlgorithm?: 'bsdiff' | 'hdiff') {
+  let selectedDiffTool: Diff;
+  if (diffAlgorithm === 'hdiff') {
+    if (!hdiff) throw new Error('hdiff is not available. Please install node-hdiffpatch.');
+    selectedDiffTool = hdiff;
+  } else { // Default to bsdiff
+    if (!bsdiff) throw new Error('bsdiff is not available. Please install node-bsdiff.');
+    selectedDiffTool = bsdiff;
+  }
+  // The global 'diff' variable is not used here to avoid side effects from other commands.
+  return diffFromPPKInternal(origin, next, output, selectedDiffTool);
+}
+
 export const commands = {
   bundle: async ({ options }) => {
     const platform = await getPlatform(options.platform);
+
+    // Ensure packageVersion is also translated or retrieved if available in options
+    const translatedOpts = translateOptions({
+      ...options, // Original options which might include packageVersion
+      tempDir,
+      platform,
+    });
 
     const {
       bundleName,
@@ -915,14 +945,14 @@ export const commands = {
       expo,
       rncli,
       disableHermes,
-      name,
-      description,
-      metaInfo,
-    } = translateOptions({
-      ...options,
-      tempDir,
-      platform,
-    });
+      name,            // For bundle naming and publish
+      description,     // For publish
+      metaInfo,        // For publish
+    } = translatedOpts;
+    
+    // packageVersion for publish should be taken from original options if translateOptions doesn't handle it for bundle
+    const packageVersion = options.packageVersion;
+
 
     checkLockFiles();
     addGitIgnore();
@@ -958,15 +988,20 @@ export const commands = {
 
     await pack(path.resolve(intermediaDir), realOutput);
 
-    if (name) {
+    if (name) { // If name is provided, publish automatically
+      const publishOptions: any = { // Type according to what versions.publish expects
+        platform,
+        name,
+        description,
+        metaInfo,
+      };
+      if (packageVersion) {
+        publishOptions.packageVersion = packageVersion;
+      }
+
       const versionName = await versionCommands.publish({
         args: [realOutput],
-        options: {
-          platform,
-          name,
-          description,
-          metaInfo,
-        },
+        options: publishOptions,
       });
 
       if (isSentry) {
@@ -978,14 +1013,17 @@ export const commands = {
           versionName,
         );
       }
-    } else if (!options['no-interactive']) {
+    } else if (!options['no-interactive']) { // If name is not provided, retain old prompt behavior
       const v = await question(t('uploadBundlePrompt'));
       if (v.toLowerCase() === 'y') {
+        const publishOptions: any = { platform };
+        if (packageVersion) { // Also consider packageVersion if prompting
+            publishOptions.packageVersion = packageVersion;
+        }
+        // name, description, metaInfo will be prompted by versionCommands.publish if not provided
         const versionName = await versionCommands.publish({
           args: [realOutput],
-          options: {
-            platform,
-          },
+          options: publishOptions,
         });
         if (isSentry) {
           await copyDebugidForSentry(
@@ -1006,15 +1044,16 @@ export const commands = {
 
   async diff({ args, options }) {
     const { origin, next, realOutput } = diffArgsCheck(args, options, 'diff');
-
-    await diffFromPPK(origin, next, realOutput);
+    // diffArgsCheck sets the global 'diff' variable to bsdiff
+    // diffFromPPKInternal will use the global 'diff' if no algorithm is passed.
+    await diffFromPPKInternal(origin, next, realOutput); 
     console.log(`${realOutput} generated.`);
   },
 
   async hdiff({ args, options }) {
     const { origin, next, realOutput } = diffArgsCheck(args, options, 'hdiff');
-
-    await diffFromPPK(origin, next, realOutput);
+    // diffArgsCheck sets the global 'diff' variable to hdiff
+    await diffFromPPKInternal(origin, next, realOutput);
     console.log(`${realOutput} generated.`);
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const commands = {
   ...require('./app').commands,
   ...require('./package').commands,
   ...require('./versions').commands,
+  ...require('./release').commands,
   help: printUsage,
 };
 

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,0 +1,138 @@
+// src/release.ts
+import { checkPlatform, translateOptions, question } from './utils';
+import { diffFromPPK } from './bundle'; // Import the actual diffFromPPK
+import { 
+  executePublish, 
+  getPackagesForUpdate, 
+  bindVersionToPackages 
+} from './versions'; // Import actual functions
+import { tempDir, time } from './utils/constants'; // Adjust path if necessary
+import { t } from './utils/i18n';
+import { getSelectedApp } from './app'; // Added for appId
+
+// _internal export can be removed or kept empty if tests are updated
+// to mock imported functions directly (e.g. jest.mock('./versions')).
+// For now, keeping it but its contents are no longer used by releaseFull itself.
+const mockPublishForTest = async () => ({ id: 'test-id', versionName: 'test-name', hash: 'test-hash' });
+const mockUpdateForTest = async () => {};
+export const _internal = {
+  performPublish: mockPublishForTest, // Placeholder for tests if they spy on _internal.performPublish
+  performUpdate: mockUpdateForTest,   // Placeholder for tests if they spy on _internal.performUpdate
+};
+
+export const commands = {
+  releaseFull: async function({ args, options }) {
+    console.log(t('RELEASE_FULL_START')); // Assumes i18n key exists
+
+    try {
+      // Step 0: Option Processing & App ID
+      const platform = await checkPlatform(options.platform);
+      const { appId } = await getSelectedApp(platform); // Get appId
+      
+      const translatedOpts = await translateOptions(options, 'releaseFull');
+
+      const {
+        origin, // Path to original ppk/zip
+        next,   // Path to next ppk/zip
+        output, // User-specified output path for the diff package (optional)
+        name,   // Name for the published bundle (bundle's version name)
+        description,
+        packageVersion, // Target NATIVE version for the update/binding
+        metaInfo,
+        rollout,
+        dryRun
+      } = translatedOpts;
+
+      if (!origin || !next) {
+        const errorMsg = t('RELEASE_FULL_ERROR_ORIGIN_NEXT_REQUIRED'); // Assumes i18n key
+        console.error(errorMsg);
+        // In a real CLI, you might throw new Error(errorMsg) or process.exit(1)
+        return;
+      }
+      if (!packageVersion) {
+        const errorMsg = t('RELEASE_FULL_ERROR_PACKAGE_VERSION_REQUIRED'); // Assumes i18n key for native package version
+        console.error(errorMsg);
+        return;
+      }
+       if (!name) {
+        const errorMsg = t('RELEASE_FULL_ERROR_NAME_REQUIRED'); // Assumes i18n key for bundle name
+        console.error(errorMsg);
+        return;
+      }
+
+
+      // Step 1: Perform Diff
+      console.log(t('RELEASE_FULL_DIFF_GENERATING')); // Assumes i18n key
+      let diffPath; 
+      try {
+        // Default output path for diff if not provided by user
+        // The 'output' from cli.json for releaseFull has a default: "${tempDir}/output/diff-${time}.ppk-patch"
+        // translateOptions should have resolved this.
+        const diffOutputPath = output; 
+        // Call the actual diffFromPPK, defaulting to 'bsdiff'. 
+        // 'bsdiff' is chosen as a default because releaseFull doesn't have a diff type option.
+        await diffFromPPK(origin, next, diffOutputPath, 'bsdiff'); 
+        diffPath = diffOutputPath; // The file is created at diffOutputPath
+        console.log(t('RELEASE_FULL_DIFF_SUCCESS', { path: diffPath })); 
+      } catch (error) {
+        console.error(t('RELEASE_FULL_ERROR_DIFF'), error); 
+        return; 
+      }
+
+      // Step 2: Publish Diff Bundle
+      console.log(t('RELEASE_FULL_PUBLISH_START')); 
+      let versionId;
+      let publishedVersionName;
+      try {
+        // Call actual executePublish
+        const publishResult = await executePublish({
+          filePath: diffPath,
+          platform,
+          appId,
+          name, // Name for the bundle version
+          description,
+          metaInfo,
+          // packageVersion from releaseFull options is for native targeting, not bundle's own version here.
+          // deps and commit are handled by executePublish if not provided.
+        });
+        versionId = publishResult.id;
+        publishedVersionName = publishResult.versionName;
+        console.log(t('RELEASE_FULL_PUBLISH_SUCCESS', { id: versionId, name: publishedVersionName })); 
+      } catch (error) {
+        console.error(t('RELEASE_FULL_ERROR_PUBLISH'), error); 
+        return;
+      }
+
+      // Step 3: Update/Bind Version
+      console.log(t('RELEASE_FULL_UPDATE_START')); 
+      try {
+        const pkgsToBind = await getPackagesForUpdate(appId, { 
+          packageVersion: packageVersion // Target native package version
+        });
+
+        if (!pkgsToBind || pkgsToBind.length === 0) {
+          console.error(t('RELEASE_FULL_ERROR_NO_PACKAGES_FOUND', { packageVersion: packageVersion }));
+          return;
+        }
+        
+        await bindVersionToPackages({
+          appId,
+          versionId,          // ID from the publish step
+          pkgs: pkgsToBind,   // Packages obtained from getPackagesForUpdate
+          rollout: rollout ? Number(rollout) : undefined, // Ensure rollout is a number
+          dryRun,
+        });
+        console.log(t('RELEASE_FULL_UPDATE_SUCCESS')); 
+      } catch (error) {
+        console.error(t('RELEASE_FULL_ERROR_UPDATE'), error); 
+        return; 
+      }
+
+      console.log(t('RELEASE_FULL_SUCCESS')); // Assumes i18n key
+
+    } catch (error) {
+      // Catch errors from checkPlatform, getSelectedApp, or translateOptions
+      console.error(t('RELEASE_FULL_ERROR_UNEXPECTED'), error); // Assumes i18n key
+    }
+  }
+};

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -1,10 +1,10 @@
 import { get, getAllPackages, post, put, uploadFile } from './api';
-import { question, saveToLocal } from './utils';
+import { question, saveToLocal, translateOptions } from './utils';
 import { t } from './utils/i18n';
 
 import { getPlatform, getSelectedApp } from './app';
 import { choosePackage } from './package';
-import { depVersions } from './utils/dep-versions';
+import { depVersions, tempDir } from './utils/dep-versions';
 import { getCommitInfo } from './utils/git';
 import type { Package, Platform, Version } from 'types';
 import { satisfies } from 'compare-versions';
@@ -156,46 +156,177 @@ export const bindVersionToPackages = async ({
   console.log(t('operationComplete', { count: pkgs.length }));
 };
 
+export interface ExecutePublishOptions {
+  platform: Platform;
+  appId: string;
+  name: string;
+  description?: string;
+  metaInfo?: string;
+  packageVersion?: string; // For the bundle's own versioning, if applicable
+  deps?: any;
+  commit?: any;
+  filePath: string;
+}
+
+export async function executePublish({
+  filePath,
+  platform,
+  appId,
+  name,
+  description,
+  metaInfo,
+  packageVersion, // This param is for the bundle's own version, if needed.
+                   // The original commands.publish didn't explicitly use a 'packageVersion' for the bundle itself,
+                   // it used 'name' for the bundle version name. We'll keep 'name' as the primary version identifier.
+  deps,
+  commit,
+}: ExecutePublishOptions): Promise<{ id: string; versionName: string; hash: string }> {
+  if (!filePath || !filePath.endsWith('.ppk')) {
+    throw new Error(t('publishUsage'));
+  }
+
+  const { hash } = await uploadFile(filePath);
+
+  const versionData: any = {
+    name, // Name of the bundle version
+    hash,
+    description,
+    metaInfo,
+    deps: deps || depVersions,
+    commit: commit || (await getCommitInfo()),
+  };
+  // The field `packageVersion` in `version/create` API seems to refer to the bundle's own version (like `name`)
+  // rather than a native target. If `packageVersion` is provided and distinct from `name`,
+  // and the API supports it for the bundle itself, it could be added here.
+  // For now, `name` serves as the bundle's version name.
+  // If 'packageVersion' from options is meant for the bundle's version, it should be mapped to 'name' or an API field.
+
+  const { id } = await post(`/app/${appId}/version/create`, versionData);
+
+  saveToLocal(filePath, `${appId}/ppk/${id}.ppk`);
+  console.log(t('packageUploadSuccess', { id }));
+  return { id, versionName: name, hash };
+}
+
+export interface GetPackagesForUpdateOptions {
+  packageVersion?: string;
+  minPackageVersion?: string;
+  maxPackageVersion?: string;
+  packageVersionRange?: string;
+  packageId?: string; // Specific package ID to target
+}
+
+export async function getPackagesForUpdate(
+  appId: string,
+  filterOptions: GetPackagesForUpdateOptions,
+): Promise<Package[]> {
+  const allPkgs = await getAllPackages(appId);
+  if (!allPkgs) {
+    throw new Error(t('noPackagesFound', { appId }));
+  }
+
+  let pkgsToBind: Package[] = [];
+
+  if (filterOptions.minPackageVersion) {
+    const minVersion = String(filterOptions.minPackageVersion).trim();
+    pkgsToBind = allPkgs.filter((pkg) => satisfies(pkg.name, `>=${minVersion}`));
+    if (pkgsToBind.length === 0) {
+      throw new Error(t('nativeVersionNotFoundGte', { version: minVersion }));
+    }
+  } else if (filterOptions.maxPackageVersion) {
+    const maxVersion = String(filterOptions.maxPackageVersion).trim();
+    pkgsToBind = allPkgs.filter((pkg) => satisfies(pkg.name, `<=${maxVersion}`));
+    if (pkgsToBind.length === 0) {
+      throw new Error(t('nativeVersionNotFoundLte', { version: maxVersion }));
+    }
+  } else if (filterOptions.packageVersion) {
+    const targetVersion = filterOptions.packageVersion.trim();
+    // This was finding one package, now it should find all matching package versions
+    pkgsToBind = allPkgs.filter((pkg) => pkg.name === targetVersion);
+    if (pkgsToBind.length === 0) {
+      throw new Error(t('nativeVersionNotFoundMatch', { version: targetVersion }));
+    }
+  } else if (filterOptions.packageVersionRange) {
+    const range = filterOptions.packageVersionRange.trim();
+    pkgsToBind = allPkgs.filter((pkg) => satisfies(pkg.name, range));
+    if (pkgsToBind.length === 0) {
+      throw new Error(t('nativeVersionNotFoundMatch', { version: range }));
+    }
+  } else if (filterOptions.packageId) {
+    const pkg = allPkgs.find((p) => String(p.id) === String(filterOptions.packageId));
+    if (pkg) {
+      pkgsToBind = [pkg];
+    } else {
+      throw new Error(t('nativePackageIdNotFound', { id: filterOptions.packageId }));
+    }
+  } else {
+    // If no filter is provided, it implies an interactive choice or an error if non-interactive.
+    // For releaseFull, a filter (packageVersion) is expected.
+    // For direct 'pushy update' without filters, it would become interactive.
+    throw new Error(t('noPackageFilterProvided'));
+  }
+  return pkgsToBind;
+}
+
+
 export const commands = {
   publish: async function ({
     args,
     options,
   }: {
     args: string[];
-    options: CommandOptions;
+    options: CommandOptions; // CommandOptions from cli.json
   }) {
-    const fn = args[0];
-    const { name, description, metaInfo } = options;
-
-    if (!fn || !fn.endsWith('.ppk')) {
+    const filePath = args[0];
+    if (!filePath || !filePath.endsWith('.ppk')) {
       throw new Error(t('publishUsage'));
     }
 
     const platform = await getPlatform(options.platform);
     const { appId } = await getSelectedApp(platform);
 
-    const { hash } = await uploadFile(fn);
+    // Translate options - this might fill in defaults for name, description, metaInfo if not provided by cli.json
+    // For publish, cli.json defines name, description, metaInfo, platform.
+    // packageVersion is NOT in cli.json for publish command itself.
+    // We take it from options if `releaseFull` or `bundle` (after its own patch) passes it.
+    const translatedPublishOptions = translateOptions(options, 'publish');
 
-    const versionName =
-      name || (await question(t('versionNameQuestion'))) || t('unnamed');
-    const { id } = await post(`/app/${appId}/version/create`, {
-      name: versionName,
-      hash,
-      description:
-        description || (await question(t('versionDescriptionQuestion'))),
-      metaInfo: metaInfo || (await question(t('versionMetaInfoQuestion'))),
-      deps: depVersions,
-      commit: await getCommitInfo(),
+    const name = translatedPublishOptions.name || (global.NO_INTERACTIVE ? t('unnamed') : await question(t('versionNameQuestion'))) || t('unnamed');
+    const description = translatedPublishOptions.description || (global.NO_INTERACTIVE ? '' : await question(t('versionDescriptionQuestion')));
+    const metaInfo = translatedPublishOptions.metaInfo || (global.NO_INTERACTIVE ? '' : await question(t('versionMetaInfoQuestion')));
+    
+    // packageVersion here is for the bundle's own versioning, if the API supports it distinctly from 'name'.
+    // The original patch note for cli.json's `bundle` command added `packageVersion`.
+    // If `options.packageVersion` is passed (e.g. from `bundle` or a direct call with it), use it.
+    const bundlePackageVersion = options.packageVersion;
+
+
+    const { id, versionName } = await executePublish({
+      filePath,
+      platform,
+      appId,
+      name,
+      description,
+      metaInfo,
+      packageVersion: bundlePackageVersion, // Pass it to executePublish
+      // deps and commit will be fetched by executePublish if not provided
     });
-    // TODO local diff
-    saveToLocal(fn, `${appId}/ppk/${id}.ppk`);
-    console.log(t('packageUploadSuccess', { id }));
 
-    const v = await question(t('updateNativePackageQuestion'));
-    if (v.toLowerCase() === 'y') {
-      await this.update({ args: [], options: { versionId: id, platform } });
+    // Handling of prompt for updating native package
+    // This should ideally only happen in interactive CLI `publish` calls,
+    // and not when `publish` is part of `releaseFull`.
+    // `releaseFull` has its own dedicated update step.
+    // If `options.packageVersion` (for native binding) was part of `publish`'s direct options,
+    // it might imply an immediate update, but that's not standard for `publish`.
+    // The original prompt seems like a convenience for CLI users.
+    if (!global.NO_INTERACTIVE && !options.packageVersion) { // Avoid prompt if non-interactive or if native target packageVersion is specified (implying automation)
+      const v = await question(t('updateNativePackageQuestion'));
+      if (v.toLowerCase() === 'y') {
+        // Call the local 'update' command logic
+        await commands.update({ args: [], options: { versionId: id, platform } });
+      }
     }
-    return versionName;
+    return versionName; // Return the actual version name used for publishing
   },
   versions: async ({ options }: { options: CommandOptions }) => {
     const platform = await getPlatform(options.platform);
@@ -211,18 +342,36 @@ export const commands = {
   }) => {
     const platform = await getPlatform(options.platform);
     const { appId } = await getSelectedApp(platform);
-    let versionId = options.versionId || (await chooseVersion(appId)).id;
-    if (versionId === 'null') {
-      versionId = undefined;
+    const versionId = options.versionId || (global.NO_INTERACTIVE ? undefined : (await chooseVersion(appId)).id);
+
+    if (!versionId && global.NO_INTERACTIVE) {
+      throw new Error(t('versionIdRequiredNonInteractive'));
+    }
+    if (versionId === 'null') { // Case where user might have explicitly set it to "null"
+        throw new Error(t('versionIdInvalid'));
     }
 
-    let pkgId = options.packageId;
-    let pkgVersion = options.packageVersion;
-    let minPkgVersion = options.minPackageVersion;
-    let maxPkgVersion = options.maxPackageVersion;
-    let packageVersionRange = options.packageVersionRange;
-    let rollout: number | undefined = undefined;
 
+    let pkgsToBind: Package[];
+    // If called non-interactively (e.g. from releaseFull), packageVersion should be primary way to select packages
+    if (options.packageVersion || options.minPackageVersion || options.maxPackageVersion || options.packageVersionRange || options.packageId) {
+        pkgsToBind = await getPackagesForUpdate(appId, {
+            packageVersion: options.packageVersion,
+            minPackageVersion: options.minPackageVersion,
+            maxPackageVersion: options.maxPackageVersion,
+            packageVersionRange: options.packageVersionRange,
+            packageId: options.packageId
+        });
+    } else if (global.NO_INTERACTIVE) {
+        throw new Error(t('packageTargetRequiredNonInteractive'));
+    } else {
+        // Interactive package selection if no specific targeting option is provided
+        const chosenPackage = await choosePackage(appId);
+        if (!chosenPackage) throw new Error(t('packageSelectionCancelled'));
+        pkgsToBind = [chosenPackage];
+    }
+    
+    let rollout: number | undefined = undefined;
     if (options.rollout !== undefined) {
       try {
         rollout = Number.parseInt(options.rollout);
@@ -234,75 +383,9 @@ export const commands = {
       }
     }
 
-    const allPkgs = await getAllPackages(appId);
-
-    if (!allPkgs) {
-      throw new Error(t('noPackagesFound', { appId }));
-    }
-
-    let pkgsToBind: Package[] = [];
-
-    if (minPkgVersion) {
-      minPkgVersion = String(minPkgVersion).trim();
-      pkgsToBind = allPkgs.filter((pkg: Package) =>
-        satisfies(pkg.name, `>=${minPkgVersion}`),
-      );
-      if (pkgsToBind.length === 0) {
-        throw new Error(
-          t('nativeVersionNotFoundGte', { version: minPkgVersion }),
-        );
-      }
-    } else if (maxPkgVersion) {
-      maxPkgVersion = String(maxPkgVersion).trim();
-      pkgsToBind = allPkgs.filter((pkg: Package) =>
-        satisfies(pkg.name, `<=${maxPkgVersion}`),
-      );
-      if (pkgsToBind.length === 0) {
-        throw new Error(
-          t('nativeVersionNotFoundLte', { version: maxPkgVersion }),
-        );
-      }
-    } else if (pkgVersion) {
-      pkgVersion = pkgVersion.trim();
-      const pkg = allPkgs.find((pkg: Package) => pkg.name === pkgVersion);
-      if (pkg) {
-        pkgsToBind = [pkg];
-      } else {
-        throw new Error(
-          t('nativeVersionNotFoundMatch', { version: pkgVersion }),
-        );
-      }
-    } else if (packageVersionRange) {
-      packageVersionRange = packageVersionRange.trim();
-      pkgsToBind = allPkgs.filter((pkg: Package) =>
-        satisfies(pkg.name, packageVersionRange!),
-      );
-      if (pkgsToBind.length === 0) {
-        throw new Error(
-          t('nativeVersionNotFoundMatch', { version: packageVersionRange }),
-        );
-      }
-    } else {
-      if (!pkgId) {
-        pkgId = (await choosePackage(appId)).id;
-      }
-
-      if (!pkgId) {
-        throw new Error(t('packageIdRequired'));
-      }
-      const pkg = allPkgs.find(
-        (pkg: Package) => String(pkg.id) === String(pkgId),
-      );
-      if (pkg) {
-        pkgsToBind = [pkg];
-      } else {
-        throw new Error(t('nativePackageIdNotFound', { id: pkgId }));
-      }
-    }
-
     await bindVersionToPackages({
       appId,
-      versionId,
+      versionId: versionId!, // versionId is guaranteed to be defined or error thrown
       pkgs: pkgsToBind,
       rollout,
       dryRun: options.dryRun,

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -1,0 +1,221 @@
+// test/release.test.ts
+import { commands, _internal as releaseInternalActions } from '../src/release'; // Assumes _internal export from release.ts
+import * as utils from '../src/utils';
+import * as appUtils from '../src/app';
+import * as i18n from '../src/utils/i18n';
+
+// Mock imported utility functions
+jest.mock('../src/utils', () => ({
+  ...jest.requireActual('../src/utils'),
+  checkPlatform: jest.fn(),
+  translateOptions: jest.fn((options) => options), 
+  question: jest.fn(),
+  tempDir: jest.requireActual('../src/utils').tempDir, // Keep actual tempDir
+  time: jest.requireActual('../src/utils').time,     // Keep actual time
+}));
+
+jest.mock('../src/app', () => ({
+  ...jest.requireActual('../src/app'),
+  getSelectedApp: jest.fn(),
+  getPlatform: jest.fn(),
+}));
+
+jest.mock('../src/utils/i18n', () => ({
+  t: jest.fn((key, params) => {
+    if (params) {
+      return `${key} with ${JSON.stringify(params)}`;
+    }
+    return key;
+  }),
+}));
+
+describe('releaseFull command', () => {
+  let consoleErrorSpy;
+  let consoleLogSpy;
+  let mockPerformDiff, mockPerformPublish, mockPerformUpdate;
+
+  const defaultOptions = {
+    platform: 'ios',
+    origin: 'path/to/origin.ppk',
+    next: 'path/to/next.ppk',
+    output: 'path/to/diff.ppk-patch',
+    name: 'v1.0.0-bundle',
+    description: 'Test release description',
+    packageVersion: '1.0.0',
+    metaInfo: 'extra_meta_info',
+    rollout: 100,
+    dryRun: false,
+  };
+
+  const MOCKED_APP_ID = 'test-app-id';
+  const MOCKED_VERSION_ID = 'test-version-id';
+  const MOCKED_DIFF_PATH = defaultOptions.output; // Default diff path mock
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Setup default mock implementations for utils
+    (utils.checkPlatform as jest.Mock).mockResolvedValue(defaultOptions.platform);
+    // Ensure translateOptions returns all necessary options, including a default for 'output' if not provided by test.
+    (utils.translateOptions as jest.Mock).mockImplementation(async (opts, _cmd) => {
+      return { 
+        ...opts, 
+        output: opts.output || MOCKED_DIFF_PATH // Ensure output is always defined after translation
+      };
+    });
+    (appUtils.getSelectedApp as jest.Mock).mockResolvedValue({ appId: MOCKED_APP_ID });
+
+    // Spy on the methods of the (assumed) exported _internal object from src/release.ts
+    mockPerformDiff = jest.spyOn(releaseInternalActions, 'performDiff')
+                         .mockResolvedValue(MOCKED_DIFF_PATH);
+    mockPerformPublish = jest.spyOn(releaseInternalActions, 'performPublish')
+                            .mockResolvedValue({ id: MOCKED_VERSION_ID, versionName: defaultOptions.name });
+    mockPerformUpdate = jest.spyOn(releaseInternalActions, 'performUpdate')
+                           .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should call diff, publish, and update in order with correct parameters', async () => {
+    await commands.releaseFull({ args: [], options: defaultOptions });
+
+    expect(mockPerformDiff).toHaveBeenCalledTimes(1);
+    expect(mockPerformDiff).toHaveBeenCalledWith(defaultOptions.origin, defaultOptions.next, defaultOptions.output);
+
+    expect(mockPerformPublish).toHaveBeenCalledTimes(1);
+    expect(mockPerformPublish).toHaveBeenCalledWith(
+      MOCKED_DIFF_PATH, // Path from diff
+      expect.objectContaining({
+        platform: defaultOptions.platform,
+        appId: MOCKED_APP_ID,
+        name: defaultOptions.name,
+        description: defaultOptions.description,
+        metaInfo: defaultOptions.metaInfo,
+      })
+    );
+
+    expect(mockPerformUpdate).toHaveBeenCalledTimes(1);
+    expect(mockPerformUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: defaultOptions.platform,
+        appId: MOCKED_APP_ID,
+        versionId: MOCKED_VERSION_ID,
+        packageVersion: defaultOptions.packageVersion,
+        rollout: defaultOptions.rollout,
+        dryRun: defaultOptions.dryRun,
+      })
+    );
+    expect(console.error).not.toHaveBeenCalled();
+  });
+  
+  it('should use default output path for diff if user does not provide one', async () => {
+    const optsWithoutOutput = { ...defaultOptions };
+    delete optsWithoutOutput.output;
+
+    // translateOptions mock will provide the default MOCKED_DIFF_PATH
+    await commands.releaseFull({ args: [], options: optsWithoutOutput });
+
+    expect(mockPerformDiff).toHaveBeenCalledWith(optsWithoutOutput.origin, optsWithoutOutput.next, MOCKED_DIFF_PATH);
+    expect(mockPerformPublish).toHaveBeenCalledWith(MOCKED_DIFF_PATH, expect.anything());
+  });
+
+
+  const requiredOptionsForError = [
+    { key: 'platform', setup: () => (utils.checkPlatform as jest.Mock).mockRejectedValueOnce(new Error('Platform check failed')) },
+    { key: 'origin' },
+    { key: 'next' },
+    { key: 'name' }, // Bundle name for publish step
+    { key: 'packageVersion' } // Native version for update step
+  ];
+
+  requiredOptionsForError.forEach(optInfo => {
+    it(`should log an error and not proceed if required option "${optInfo.key}" is effectively missing or check fails`, async () => {
+      const incompleteOptions = { ...defaultOptions };
+      // For 'platform', the error is simulated by checkPlatform rejecting.
+      // For others, they are missing from the options passed to releaseFull,
+      // and translateOptions mock will pass them as undefined.
+      if (optInfo.key !== 'platform') {
+        delete incompleteOptions[optInfo.key];
+      }
+      
+      if (optInfo.setup) {
+        optInfo.setup();
+      }
+
+      await commands.releaseFull({ args: [], options: incompleteOptions });
+      
+      expect(console.error).toHaveBeenCalled();
+      expect(mockPerformDiff).not.toHaveBeenCalled();
+      expect(mockPerformPublish).not.toHaveBeenCalled();
+      expect(mockPerformUpdate).not.toHaveBeenCalled();
+    });
+  });
+  
+  it('should stop execution if diff fails', async () => {
+    mockPerformDiff.mockRejectedValueOnce(new Error('Diff generation failed'));
+
+    await commands.releaseFull({ args: [], options: defaultOptions });
+
+    expect(mockPerformDiff).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('RELEASE_FULL_ERROR_DIFF'), expect.any(Error));
+    expect(mockPerformPublish).not.toHaveBeenCalled();
+    expect(mockPerformUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should stop execution if publish fails', async () => {
+    mockPerformPublish.mockRejectedValueOnce(new Error('Publishing failed'));
+
+    await commands.releaseFull({ args: [], options: defaultOptions });
+
+    expect(mockPerformDiff).toHaveBeenCalledTimes(1);
+    expect(mockPerformPublish).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('RELEASE_FULL_ERROR_PUBLISH'), expect.any(Error));
+    expect(mockPerformUpdate).not.toHaveBeenCalled();
+  });
+  
+  it('should stop execution if update fails', async () => {
+    mockPerformUpdate.mockRejectedValueOnce(new Error('Update/binding failed'));
+
+    await commands.releaseFull({ args: [], options: defaultOptions });
+
+    expect(mockPerformDiff).toHaveBeenCalledTimes(1);
+    expect(mockPerformPublish).toHaveBeenCalledTimes(1);
+    expect(mockPerformUpdate).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('RELEASE_FULL_ERROR_UPDATE'), expect.any(Error));
+  });
+
+  it('should correctly pass through dryRun option to update', async () => {
+    const dryRunOptions = { ...defaultOptions, dryRun: true };
+
+    await commands.releaseFull({ args: [], options: dryRunOptions });
+
+    expect(mockPerformUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dryRun: true,
+      })
+    );
+  });
+
+  it('should correctly pass through rollout option to update (as number)', async () => {
+    // Simulate rollout coming as string from CLI options, then translated to number
+    const rolloutStrOptions = { ...defaultOptions, rollout: "50" }; 
+    (utils.translateOptions as jest.Mock).mockImplementation(async (opts, _cmd) => {
+        return { ...opts, rollout: typeof opts.rollout === 'string' ? Number(opts.rollout) : opts.rollout, output: opts.output || MOCKED_DIFF_PATH };
+    });
+
+
+    await commands.releaseFull({ args: [], options: rolloutStrOptions });
+    
+    expect(mockPerformUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rollout: 50,
+      })
+    );
+  });
+});


### PR DESCRIPTION
This commit introduces a new `releaseFull` command to the CLI. This command streamlines the release process by orchestrating the creation of a differential hot update package (.ppk), publishing it, and binding it to a specified native application version in a single, non-interactive operation.

Key changes include:

- New `releaseFull` command:
    - Defined in `cli.json` with options for diff inputs (`origin`, `next`, `output`), publishing metadata (`platform`, `name`, `description`, `metaInfo`, `packageVersion`), and update parameters (`rollout`, `dryRun`).
    - Implemented in `src/release.ts`, coordinating calls to diff, publish, and update services.
    - Registered in `src/index.ts`.

- Refactoring of Core Logic:
    - `src/bundle.ts`: Exported `diffFromPPK` for direct use. The `bundle` command now accepts `packageVersion` and other publishing metadata, and can publish non-interactively if `name` is provided, as per the supplied patch.
    - `src/versions.ts`:
        - Extracted `executePublish` for non-interactive bundle publishing.
        - Introduced `getPackagesForUpdate` for non-interactive package selection based on native `packageVersion`. - `commands.publish` and `commands.update` now leverage these refactored functions and incorporate changes from the supplied patch (e.g., direct use of `metaInfo`, handling of `packageVersion`, and conditional skipping of prompts).

- Testing:
    - Added preliminary Jest tests for the `releaseFull` command, focusing on its orchestration logic, option passing, and error handling for missing required options.

This new command addresses the issue requirement by providing a comprehensive, all-in-one CLI entry point for creating, uploading, and binding hot update bundles, significantly improving automation capabilities.