### PR TITLE
🔒 [security] Secure Storage of Session Token and App Keys

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -62,7 +62,8 @@ export const saveSession = () => {
   if (session !== savedSession) {
     const current = session;
     const data = JSON.stringify(current, null, 4);
-    fs.writeFileSync(credentialFile, data, 'utf8');
+    fs.writeFileSync(credentialFile, data, { encoding: 'utf8', mode: 0o600 });
+    fs.chmodSync(credentialFile, 0o600);
     savedSession = current;
   }
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { question } from './utils';
 
 import { doDelete, get, post } from './api';
 import type { Platform } from './types';
+import { updateJson } from './utils/constants';
 import { t } from './utils/i18n';
 
 interface AppSummary {
@@ -125,9 +126,9 @@ export const appCommands = {
     let updateInfo: Partial<
       Record<Platform, { appId: number; appKey: string }>
     > = {};
-    if (fs.existsSync('update.json')) {
+    if (fs.existsSync(updateJson)) {
       try {
-        updateInfo = JSON.parse(fs.readFileSync('update.json', 'utf8'));
+        updateInfo = JSON.parse(fs.readFileSync(updateJson, 'utf8'));
       } catch (e) {
         console.error(t('failedToParseUpdateJson'));
         throw e;
@@ -138,10 +139,10 @@ export const appCommands = {
       appId: id,
       appKey,
     };
-    fs.writeFileSync(
-      'update.json',
-      JSON.stringify(updateInfo, null, 4),
-      'utf8',
-    );
+    fs.writeFileSync(updateJson, JSON.stringify(updateInfo, null, 4), {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    fs.chmodSync(updateJson, 0o600);
   },
 };

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,140 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
+
+// Mock missing dependencies BEFORE any imports
+mock.module('tty-table', () => ({
+  __esModule: true,
+  default: class Table {
+    constructor() {}
+    render() { return 'mocked table'; }
+  },
+}));
+mock.module('i18next', () => ({
+  __esModule: true,
+  default: {
+    use: () => ({
+      init: () => {},
+      t: (key: string) => key,
+    }),
+    t: (key: string) => key,
+  },
+  t: (key: string) => key,
+}));
+mock.module('chalk', () => ({
+  __esModule: true,
+  default: {
+    green: (s: string) => s,
+    red: (s: string) => s,
+    yellow: (s: string) => s,
+    blue: (s: string) => s,
+    cyan: (s: string) => s,
+    magenta: (s: string) => s,
+  },
+}));
+mock.module('filesize-parser', () => ({
+  __esModule: true,
+  default: (s: string) => 1024,
+}));
+mock.module('form-data', () => ({
+  __esModule: true,
+  default: class FormData {
+    append() {}
+  },
+}));
+mock.module('node-fetch', () => ({
+  __esModule: true,
+  default: mock(async () => ({
+    ok: true,
+    json: async () => ({}),
+  })),
+}));
+mock.module('progress', () => ({
+  __esModule: true,
+  default: class ProgressBar {
+    tick() {}
+  },
+}));
+mock.module('tcp-ping', () => ({
+  __esModule: true,
+  ping: (opts: any, cb: any) => cb(null, { avg: 10 }),
+}));
+mock.module('fs-extra', () => ({
+  __esModule: true,
+  default: {
+    ensureDirSync: () => {},
+    readFileSync: (f: string, e: string) => '{}',
+    existsSync: () => true,
+  },
+}));
+mock.module('read', () => ({
+  __esModule: true,
+  read: async () => 'mocked input',
+}));
+mock.module('compare-versions', () => ({
+  __esModule: true,
+  satisfies: () => true,
+}));
+
+import fs from 'fs';
+import { saveSession, replaceSession } from '../src/api';
+import { appCommands } from '../src/app';
+import { credentialFile } from '../src/utils/constants';
+
+// Mock the get function in api.ts
+mock.module('../src/api', () => {
+  const original = require('../src/api');
+  return {
+    ...original,
+    get: mock(async () => ({ appKey: 'test-app-key' })),
+  };
+});
+
+describe('Security: File Permissions', () => {
+  const testFiles = [credentialFile, 'update.json', 'cresc.config.json'];
+
+  beforeEach(() => {
+    // Clean up any existing files
+    for (const file of testFiles) {
+      if (fs.existsSync(file)) {
+        fs.unlinkSync(file);
+      }
+    }
+  });
+
+  afterEach(() => {
+    // Clean up
+    for (const file of testFiles) {
+      if (fs.existsSync(file)) {
+        fs.unlinkSync(file);
+      }
+    }
+  });
+
+  test('saveSession should create credentialFile with 0o600 permissions', () => {
+    replaceSession({ token: 'test-token' });
+    saveSession();
+
+    expect(fs.existsSync(credentialFile)).toBe(true);
+    const stats = fs.statSync(credentialFile);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  test('selectApp should create update.json with 0o600 permissions', async () => {
+    await appCommands.selectApp({
+      args: ['123'],
+      options: { platform: 'ios' },
+    });
+
+    const targetFile = 'update.json';
+    expect(fs.existsSync(targetFile)).toBe(true);
+    const stats = fs.statSync(targetFile);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -12,7 +12,6 @@ import {
 mock.module('tty-table', () => ({
   __esModule: true,
   default: class Table {
-    constructor() {}
     render() { return 'mocked table'; }
   },
 }));


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses a security vulnerability where sensitive credential and configuration files (session tokens and app keys) were being stored with default (insecure) file permissions.

⚠️ **Risk:** The potential impact if left unfixed
If these files are stored with default permissions (often `0o664` or `0o644`), other users on the same multi-user system could potentially read the session tokens or app keys, leading to unauthorized access to the user's account or applications.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix ensures that these files are created and maintained with `0o600` (read/write for owner only) permissions. This is achieved by:
1.  Passing `{ mode: 0o600 }` to `fs.writeFileSync`.
2.  Calling `fs.chmodSync(file, 0o600)` immediately after writing to handle cases where the file already exists (as `writeFileSync` does not change permissions on existing files).
3.  Refactoring `src/app.ts` to use the branding-aware `updateJson` constant instead of a hardcoded string.


---
*PR created automatically by Jules for task [2150250182784982543](https://jules.google.com/task/2150250182784982543) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file permission handling for credential and configuration files to ensure secure access controls.

* **Tests**
  * Added security tests to validate file permission configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->