### PR TITLE
🧪 Add test coverage for cross-brand constants logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "cli.json"
   ],
   "scripts": {
-    "build": "rm -rf lib && swc src -d lib --strip-leading-paths && bun run typecheck:build && chmod +x lib/bin.js",
-    "prepublishOnly": "bun run build",
+    "build": "rm -rf lib && swc src -d lib --strip-leading-paths && npm run typecheck:build && chmod +x lib/bin.js",
+    "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",
     "typecheck:build": "tsc -p tsconfig.build.json",
     "lint": "bun run typecheck && biome check .",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "cli.json"
   ],
   "scripts": {
-    "build": "rm -rf lib && swc src -d lib --strip-leading-paths && npm run typecheck:build && chmod +x lib/bin.js",
-    "prepublishOnly": "npm run build",
+    "build": "rm -rf lib && swc src -d lib --strip-leading-paths && bun run typecheck:build && chmod +x lib/bin.js",
+    "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit",
     "typecheck:build": "tsc -p tsconfig.build.json",
     "lint": "bun run typecheck && biome check .",

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -18,7 +18,10 @@ describe('constants', () => {
     expect(mod.updateJson).toBe('cresc.config.json');
     expect(mod.tempDir).toBe('.cresc.temp');
     expect(mod.pricingPageUrl).toBe('https://cresc.dev/pricing');
-    expect(mod.defaultEndpoints).toEqual(['https://api.cresc.dev', 'https://api.cresc.app']);
+    expect(mod.defaultEndpoints).toEqual([
+      'https://api.cresc.dev',
+      'https://api.cresc.app',
+    ]);
   });
 
   it('should initialize correctly when script is pushy', async () => {
@@ -28,8 +31,13 @@ describe('constants', () => {
     expect(mod.credentialFile).toBe('.update');
     expect(mod.updateJson).toBe('update.json');
     expect(mod.tempDir).toBe('.pushy');
-    expect(mod.pricingPageUrl).toBe('https://pushy.reactnative.cn/pricing.html');
-    expect(mod.defaultEndpoints).toEqual(['https://update.reactnative.cn/api', 'https://update.react-native.cn/api']);
+    expect(mod.pricingPageUrl).toBe(
+      'https://pushy.reactnative.cn/pricing.html',
+    );
+    expect(mod.defaultEndpoints).toEqual([
+      'https://update.reactnative.cn/api',
+      'https://update.react-native.cn/api',
+    ]);
   });
 
   it('should identify PPK bundle file names correctly', async () => {

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from 'bun:test';
 const loadConstantsWithArgv = async (argv1: string) => {
   const originalArgv = process.argv;
   process.argv = ['node', argv1];
-  const url = `../src/utils/constants.ts?t=${Date.now()}_${Math.random()}`;
-  const mod = await import(url);
-  process.argv = originalArgv;
-  return mod;
+  try {
+    const url = `../src/utils/constants.ts?t=${Date.now()}_${Math.random()}`;
+    const mod = await import(url);
+    return mod;
+  } finally {
+    process.argv = originalArgv;
+  }
 };
 
 describe('constants', () => {

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+
+const loadConstantsWithArgv = async (argv1: string) => {
+  const originalArgv = process.argv;
+  process.argv = ['node', argv1];
+  const url = `../src/utils/constants.ts?t=${Date.now()}_${Math.random()}`;
+  const mod = await import(url);
+  process.argv = originalArgv;
+  return mod;
+};
+
+describe('constants', () => {
+  it('should initialize correctly when script is cresc', async () => {
+    const mod = await loadConstantsWithArgv('/usr/local/bin/cresc');
+    expect(mod.scriptName).toBe('cresc');
+    expect(mod.IS_CRESC).toBe(true);
+    expect(mod.credentialFile).toBe('.cresc.token');
+    expect(mod.updateJson).toBe('cresc.config.json');
+    expect(mod.tempDir).toBe('.cresc.temp');
+    expect(mod.pricingPageUrl).toBe('https://cresc.dev/pricing');
+    expect(mod.defaultEndpoints).toEqual(['https://api.cresc.dev', 'https://api.cresc.app']);
+  });
+
+  it('should initialize correctly when script is pushy', async () => {
+    const mod = await loadConstantsWithArgv('/usr/local/bin/pushy');
+    expect(mod.scriptName).toBe('pushy');
+    expect(mod.IS_CRESC).toBe(false);
+    expect(mod.credentialFile).toBe('.update');
+    expect(mod.updateJson).toBe('update.json');
+    expect(mod.tempDir).toBe('.pushy');
+    expect(mod.pricingPageUrl).toBe('https://pushy.reactnative.cn/pricing.html');
+    expect(mod.defaultEndpoints).toEqual(['https://update.reactnative.cn/api', 'https://update.react-native.cn/api']);
+  });
+
+  it('should identify PPK bundle file names correctly', async () => {
+    const { isPPKBundleFileName } = await import('../src/utils/constants.ts');
+    expect(isPPKBundleFileName('index.bundlejs')).toBe(true);
+    expect(isPPKBundleFileName('bundle.harmony.js')).toBe(true);
+    expect(isPPKBundleFileName('index.js')).toBe(false);
+    expect(isPPKBundleFileName('main.bundlejs')).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** 
Added a test suite (`tests/constants.test.ts`) to verify the module-level evaluation of constants within `src/utils/constants.ts`. The script evaluates values depending on `process.argv` dynamically.

📊 **Coverage:**
- Tests `IS_CRESC`, `scriptName`, `credentialFile`, `updateJson`, `tempDir`, `pricingPageUrl`, and `defaultEndpoints` mapping when `process.argv` mimics a "cresc" run.
- Tests the exact same mappings when `process.argv` mimics a "pushy" run.
- Validates the `isPPKBundleFileName` utility logic.

✨ **Result:**
The constants logic is now deterministically tested and guarded against accidental modifications that would break cross-brand behaviors. Module cache busting via dynamic imports guarantees clean independent tests.

---
*PR created automatically by Jules for task [17454415258068094899](https://jules.google.com/task/17454415258068094899) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite validating script-specific constant exports and verifying bundle filename classification logic across multiple scenarios.

* **Chores**
  * Updated build and prepublish scripts to invoke the typecheck/build pipeline via npm run instead of bun run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-update-cli/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->