### PR TITLE
🧪 Add tests for testUrls edge cases and fix fallback

### DIFF
--- a/src/utils/http-helper.ts
+++ b/src/utils/http-helper.ts
@@ -57,7 +57,12 @@ export const testUrls = async (urls?: string[]) => {
   if (!urls?.length) {
     return null;
   }
-  const ret = await promiseAny(urls.map(ping));
+  let ret: string | null = null;
+  try {
+    ret = await promiseAny(urls.map(ping));
+  } catch (e) {
+    // fallback to urls[0]
+  }
   if (ret) {
     return ret;
   }

--- a/src/utils/http-helper.ts
+++ b/src/utils/http-helper.ts
@@ -60,7 +60,7 @@ export const testUrls = async (urls?: string[]) => {
   let ret: string | null = null;
   try {
     ret = await promiseAny(urls.map(ping));
-  } catch (e) {
+  } catch (_e) {
     // fallback to urls[0]
   }
   if (ret) {

--- a/tests/http-helper.test.ts
+++ b/tests/http-helper.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test } from 'bun:test';
+
+import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
+
+const runtimeFetchMock = mock(() => Promise.resolve({ status: 200 }));
+mock.module('../src/utils/runtime', () => ({
+  runtimeFetch: runtimeFetchMock,
+}));
+
 import { promiseAny, testUrls } from '../src/utils/http-helper';
 
 describe('promiseAny', () => {
@@ -39,5 +46,47 @@ describe('testUrls', () => {
   test('returns null for undefined', async () => {
     const result = await testUrls(undefined);
     expect(result).toBeNull();
+  });
+});
+
+describe('testUrls edge cases', () => {
+  afterEach(() => {
+    runtimeFetchMock.mockReset();
+  });
+
+  test('Happy Path: returns successful URL', async () => {
+    runtimeFetchMock.mockImplementation((url: string) => {
+      if (url === 'http://success.local') {
+        return Promise.resolve({ status: 200 });
+      }
+      return Promise.reject(new Error('fail'));
+    });
+
+    const result = await testUrls(['http://fail.local', 'http://success.local']);
+    expect(result).toBe('http://success.local');
+  });
+
+  test('Fastest Response: returns the URL that resolves first', async () => {
+    runtimeFetchMock.mockImplementation((url: string) => {
+      if (url === 'http://fast.local') {
+        return new Promise((resolve) => setTimeout(() => resolve({ status: 200 }), 10));
+      }
+      if (url === 'http://slow.local') {
+        return new Promise((resolve) => setTimeout(() => resolve({ status: 200 }), 50));
+      }
+      return Promise.reject(new Error('fail'));
+    });
+
+    const result = await testUrls(['http://slow.local', 'http://fast.local']);
+    expect(result).toBe('http://fast.local');
+  });
+
+  test('All Failures (Fallback): returns urls[0] without throwing', async () => {
+    runtimeFetchMock.mockImplementation(() => {
+      return Promise.resolve({ status: 500 });
+    });
+
+    const result = await testUrls(['http://fail1.local', 'http://fail2.local']);
+    expect(result).toBe('http://fail1.local');
   });
 });

--- a/tests/http-helper.test.ts
+++ b/tests/http-helper.test.ts
@@ -1,4 +1,3 @@
-
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 
 const runtimeFetchMock = mock(() => Promise.resolve({ status: 200 }));
@@ -73,13 +72,13 @@ describe('testUrls edge cases', () => {
     runtimeFetchMock.mockImplementation((url: string) => {
       if (url === 'http://fast.local') {
         return new Promise((resolve) =>
-        setTimeout(() => resolve({ status: 200 }), 10),
-      );
+          setTimeout(() => resolve({ status: 200 }), 10),
+        );
       }
       if (url === 'http://slow.local') {
         return new Promise((resolve) =>
-        setTimeout(() => resolve({ status: 200 }), 50),
-      );
+          setTimeout(() => resolve({ status: 200 }), 50),
+        );
       }
       return Promise.reject(new Error('fail'));
     });

--- a/tests/http-helper.test.ts
+++ b/tests/http-helper.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 
 const runtimeFetchMock = mock(() => Promise.resolve({ status: 200 }));
 mock.module('../src/utils/runtime', () => ({
@@ -62,17 +62,24 @@ describe('testUrls edge cases', () => {
       return Promise.reject(new Error('fail'));
     });
 
-    const result = await testUrls(['http://fail.local', 'http://success.local']);
+    const result = await testUrls([
+      'http://fail.local',
+      'http://success.local',
+    ]);
     expect(result).toBe('http://success.local');
   });
 
   test('Fastest Response: returns the URL that resolves first', async () => {
     runtimeFetchMock.mockImplementation((url: string) => {
       if (url === 'http://fast.local') {
-        return new Promise((resolve) => setTimeout(() => resolve({ status: 200 }), 10));
+        return new Promise((resolve) =>
+        setTimeout(() => resolve({ status: 200 }), 10),
+      );
       }
       if (url === 'http://slow.local') {
-        return new Promise((resolve) => setTimeout(() => resolve({ status: 200 }), 50));
+        return new Promise((resolve) =>
+        setTimeout(() => resolve({ status: 200 }), 50),
+      );
       }
       return Promise.reject(new Error('fail'));
     });


### PR DESCRIPTION
🎯 **What:** Handled `promiseAny` rejection to prevent unhandled promise rejections when all `testUrls` calls fail, safely falling back to `urls[0]`.
📊 **Coverage:** Added tests to cover the happy path (200 OK), the fastest response test (using `Promise.race` logic with `mock.module`), and the fallback edge case when all URLs reject. 
✨ **Result:** A more robust URL selection system with tests validating the exact behavior instead of relying on unpredictable environment configuration.

---
*PR created automatically by Jules for task [4000577860789812473](https://jules.google.com/task/4000577860789812473) started by @sunnylqm*