### PR TITLE
🧪 Add test for error path in loadSession

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -67,7 +67,6 @@ describe('api.ts session management', () => {
     await expect(loadSession()).rejects.toThrow(SyntaxError);
   });
 
-
   test('loadSession throws when reading credential file fails', async () => {
     existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
     readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(() => {
@@ -76,7 +75,7 @@ describe('api.ts session management', () => {
 
     await expect(loadSession()).rejects.toThrow('Read error');
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to parse file')
+      expect.stringContaining('Failed to parse file'),
     );
   });
   test('replaceSession sets session', () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -67,6 +67,18 @@ describe('api.ts session management', () => {
     await expect(loadSession()).rejects.toThrow(SyntaxError);
   });
 
+
+  test('loadSession throws when reading credential file fails', async () => {
+    existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
+    readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('Read error');
+    });
+
+    await expect(loadSession()).rejects.toThrow('Read error');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse file')
+    );
+  });
   test('replaceSession sets session', () => {
     replaceSession({ token: 'new-token' });
     expect(getSession()?.token).toBe('new-token');


### PR DESCRIPTION
🎯 **What:** Adds a test case for when `fs.readFileSync` throws an error during `loadSession`.
📊 **Coverage:** The `try...catch` block error handler in `src/api.ts` `loadSession` is now explicitly covered.
✨ **Result:** Test coverage for `src/api.ts` improves by capturing the error condition.

---
*PR created automatically by Jules for task [16815847053305162566](https://jules.google.com/task/16815847053305162566) started by @sunnylqm*