### PR TITLE
🔒 replace predictable temp dir with fs.mkdtemp in zip-entries

### DIFF
--- a/src/utils/zip-entries.ts
+++ b/src/utils/zip-entries.ts
@@ -143,11 +143,9 @@ export async function enumZipEntries(
               !entry.fileName.endsWith('/') &&
               entry.fileName.toLowerCase().endsWith('.hap')
             ) {
-              const tempDir = path.join(
-                os.tmpdir(),
-                `nested_zip_${Date.now()}`,
+              const tempDir = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'nested_zip_'),
               );
-              await fs.ensureDir(tempDir);
               const tempZipPath = path.join(tempDir, 'temp.zip');
 
               await new Promise((res, rej) => {


### PR DESCRIPTION
🎯 **What:** The `enumZipEntries` function in `src/utils/zip-entries.ts` previously used a predictable mechanism based on `Date.now()` combined with a static prefix to create temporary directories for extracting `.hap` contents. This vulnerability has been fixed.
  
⚠️ **Risk:** The previous approach, which essentially relied on generating predictable identifiers (timestamps), created a predictable temporary file path. This posed a security risk as a malicious process running on the same machine could guess the directory name, potentially leading to unauthorized data access, file tampering, or collision-based Denial of Service before or during extraction.

🛡️ **Solution:** To mitigate this vulnerability, the fix leverages the secure `fs.mkdtemp()` method (from the `fs-extra`/`fs.promises` library) which appends securely generated pseudo-random characters to the directory prefix. This guarantees directory name uniqueness and prevents prediction by malicious actors. Testing confirmed no regressions in functionality, formatting or performance with zip entry resolution.

---
*PR created automatically by Jules for task [16770242411467217764](https://jules.google.com/task/16770242411467217764) started by @sunnylqm*