### PR TITLE
fix: resolve biome formatter lint errors

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -262,8 +262,7 @@ export async function uploadFile(fn: string, key?: string) {
     });
   } catch (error) {
     if (isProxyRelatedError(error)) {
-      const rawMessage =
-        error instanceof Error ? error.message : String(error);
+      const rawMessage = error instanceof Error ? error.message : String(error);
       throw new Error(
         `${rawMessage}\n\n${t('proxyNetworkError')}\n${t('proxyNetworkErrorTips')}`,
       );

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -184,5 +184,6 @@ This can reduce the risk of inconsistent dependencies and supply chain attacks.
   apkExtracted: 'APK extracted to {{output}}',
   proxyNetworkError:
     'Network error — likely caused by a proxy/VPN. Please try disabling your proxy and retry.',
-  proxyNetworkErrorTips: 'Common fixes:\n1. Disable system proxy or VPN\n2. Check HTTP_PROXY / HTTPS_PROXY environment variables\n3. Check proxy settings in .npmrc',
+  proxyNetworkErrorTips:
+    'Common fixes:\n1. Disable system proxy or VPN\n2. Check HTTP_PROXY / HTTPS_PROXY environment variables\n3. Check proxy settings in .npmrc',
 };

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -170,5 +170,6 @@ export default {
   apkExtracted: 'APK 已提取到 {{output}}',
   proxyNetworkError:
     '网络连接异常，可能是代理/VPN 导致。请尝试关闭代理后重试。',
-  proxyNetworkErrorTips: '常见解决方法：\n1. 关闭系统代理或 VPN\n2. 检查 HTTP_PROXY / HTTPS_PROXY 环境变量\n3. 检查 .npmrc 中的 proxy 配置',
+  proxyNetworkErrorTips:
+    '常见解决方法：\n1. 关闭系统代理或 VPN\n2. 检查 HTTP_PROXY / HTTPS_PROXY 环境变量\n3. 检查 .npmrc 中的 proxy 配置',
 };


### PR DESCRIPTION
## Summary

修复 biome check 报出的 3 个格式化错误：

- `src/api.ts`: 多行三元表达式合并为单行
- `src/locales/en.ts`: 长字符串值换行
- `src/locales/zh.ts`: 长字符串值换行

## Test Plan

- [x] `bun run lint` 通过，无报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling logic for improved code clarity.

* **Style**
  * Reformatted localization configuration files for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->