### PR TITLE
feat(diff): emit copiesCrc for content-based resource matching (fix AAB image hot update)

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -223,6 +223,13 @@ async function diffFromPackage(
 
   let originSource: Buffer | undefined;
 
+  // Content checksum (CRC32) for entries that are copied from a *different*
+  // path in the origin package ("moved" entries). On Android these are the
+  // res/ drawables (images), whose on-device path differs between an APK
+  // baseline and an AAB(split-apk) install due to resource path shortening,
+  // so the client cannot locate them by path and must fall back to content.
+  const copiesCrc: Record<string, number> = {};
+
   await enumZipEntries(origin, async (entry, zipFile) => {
     if (!/\/$/.test(entry.fileName)) {
       const fn = transformPackagePath(entry.fileName);
@@ -281,6 +288,10 @@ async function diffFromPackage(
       const movedFrom = originMap[entry.crc32];
       if (movedFrom) {
         copies[entry.fileName] = movedFrom;
+        // Record the content checksum so the client can locate this file by
+        // content when the origin path does not exist verbatim on device
+        // (APK baseline -> AAB install path shortening).
+        copiesCrc[entry.fileName] = entry.crc32;
         return;
       }
 
@@ -313,7 +324,7 @@ async function diffFromPackage(
     }
   });
 
-  const diffManifest = Buffer.from(JSON.stringify({ copies }));
+  const diffManifest = Buffer.from(JSON.stringify({ copies, copiesCrc }));
   zipfile.addBuffer(
     diffManifest,
     '__diff.json',

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -401,6 +401,65 @@ describe('diff commands', () => {
     expect(result.files['assets/new.txt']?.toString('utf-8')).toBe('new-file');
   });
 
+  test('hdiffFromApk emits copiesCrc for moved (res/) entries only', async () => {
+    const originPath = path.join(tempRoot, 'origin-crc.apk');
+    const nextPath = path.join(tempRoot, 'next-crc.ppk');
+    const outputPath = path.join(tempRoot, 'out', 'apk-crc-diff.ppk');
+
+    const imageContent = Buffer.concat([
+      Buffer.from('RIFF'),
+      Buffer.from([0x10, 0x00, 0x00, 0x00]),
+      Buffer.from('WEBPVP8 image-bytes'),
+    ]);
+
+    // origin (APK layout): image lives under res/drawable-*-v4 with a full
+    // readable path; an asset under assets/ keeps a stable path.
+    await createZip(originPath, {
+      'assets/index.android.bundle': 'old-bundle',
+      'res/drawable-xhdpi-v4/x.webp': imageContent,
+      'assets/keep.txt': 'keep-content',
+    });
+    // next (ppk layout from --assets-dest): image is at root drawable-* (moved),
+    // the asset keeps its assets/ path (same content -> same path).
+    await createZip(nextPath, {
+      'index.bundlejs': 'new-bundle',
+      'drawable-xhdpi/x.webp': imageContent,
+      'assets/keep.txt': 'keep-content',
+    });
+
+    await diffCommands.hdiffFromApk(
+      createContext([originPath, nextPath], {
+        output: outputPath,
+        customDiff: () => Buffer.from('patch'),
+      }),
+    );
+
+    // crc32 of the image as stored in the origin package
+    let originImageCrc = -1;
+    await enumZipEntries(originPath, async (entry) => {
+      if (entry.fileName === 'res/drawable-xhdpi-v4/x.webp') {
+        originImageCrc = entry.crc32;
+      }
+    });
+
+    const result = await readZipContent(outputPath);
+    const diffMeta = JSON.parse(
+      result.files['__diff.json'].toString('utf-8'),
+    ) as {
+      copies: Record<string, string>;
+      copiesCrc: Record<string, number>;
+    };
+
+    // moved res/ image -> path recorded in copies, crc recorded in copiesCrc
+    expect(diffMeta.copies['drawable-xhdpi/x.webp']).toBe(
+      'res/drawable-xhdpi-v4/x.webp',
+    );
+    expect(diffMeta.copiesCrc['drawable-xhdpi/x.webp']).toBe(originImageCrc);
+    // same-path asset -> no crc needed (efficiency: only moved entries get one)
+    expect(diffMeta.copies['assets/keep.txt']).toBe('');
+    expect(diffMeta.copiesCrc['assets/keep.txt']).toBeUndefined();
+  });
+
   test('hdiffFromIpa ignores non-payload files when resolving origin package path', async () => {
     const originPath = path.join(tempRoot, 'origin-non-payload.ipa');
     const nextPath = path.join(tempRoot, 'next-non-payload.ppk');


### PR DESCRIPTION
## Problem

热更新「上传 APK 基线 + 设备运行 AAB(Google Play 拆分包)」组合下,WebP 图片加载不出来。

`diffFromPackage` 把同内容文件以**路径**写进 `copies`(`copies[to] = movedFrom`,Android `hdiffFromApk` 的 `transformPackagePath` 为恒等),客户端只能按路径在设备包里找。但:

- ppk 里图片在根级 `drawable-*/foo.webp`,APK 基线里在 `res/drawable-*-v4/foo.webp` → 每张图片都走 moved 分支,`from = res/...`。
- AAB 设备拆分包对 `res/` 做了**资源路径压缩**,同一张图变成 `res/xY.webp`,可读全名不存在 → 路径匹配落空 → 图片缺失。
- `assets/` 路径稳定,不受影响 → 只有图片挂。

历史上 #512 曾用 `copiesv2`(CRC32 内容匹配)修过,后被移除退化成纯路径启发式。

## Change

`__diff.json` 新增可选字段 `copiesCrc`,与 `copies` 并列(键=目标路径 `to`,值=内容 CRC32):

```json
{
  "copies":    { "drawable-xhdpi/x.webp": "res/drawable-xhdpi-v4/x.webp" },
  "copiesCrc": { "drawable-xhdpi/x.webp": 2746328104 }
}
```

CRC32 对 zip 条目算的是**解压后内容**,只要图片字节一致(webp 在 APK/AAB 通常原样存储),crc 就一致,天然跨 APK/AAB 格式。客户端在路径找不到时按内容命中。

### 设计取舍(高效 + 兼容)
- **只对 moved 分支输出**(图片那批);`''` 同路径条目稳定,不输出 → 清单只为图片多「一路径+一数字」。
- **键用 `to`(唯一)**,避免同内容(同 crc)互相覆盖(弃用旧 `copiesv2` 的 crc→to)。
- **完全向后兼容**:旧客户端忽略该字段、行为不变;新客户端遇到没有该字段的旧清单 → 退回路径匹配,不回归。
- 仅改 `diffFromPackage`;`diffFromPPK`(磁盘文件补丁、路径稳定)不动。

## Test
- `tests/diff.test.ts` 新增用例:断言 moved 的 `res/` 图片进 `copiesCrc` 且值等于其 crc32、`assets/` 同路径文件不进 `copiesCrc`。
- `bun test tests/diff.test.ts` → 13 pass / 0 fail。

## 客户端配套
需配合 react-native-update 客户端(Android `BundledResourceCopier` 增加 CRC 内容兜底层)。对应 PR 见 reactnativecn/react-native-update。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced file relocation tracking: Files moved to different locations now include content checksums, enabling improved identification and validation of relocated content across various package transformation scenarios.

* **Tests**
  * Added tests for checksum generation and tracking during file relocation operations, verifying accurate assignment and content correlation for moved entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->