### PR TITLE
🧪 Add tests for app-info-parser Zip class

### DIFF
--- a/tests/app-info-zip.test.ts
+++ b/tests/app-info-zip.test.ts
@@ -93,4 +93,97 @@ suffix`,
     expect(info.mobileProvision.TeamName).toBe('ReactNativeCN');
     expect(info.icon).toBe(null);
   });
+
+  test('getEntry reads a single entry by string and regex', async () => {
+    const zipPath = path.join(tempRoot, 'app.zip');
+    await writeZip(zipPath, {
+      'test.txt': 'hello world',
+      'foo.bar': 'baz',
+    });
+
+    const zip = new Zip(zipPath);
+
+    // By string
+    const buf1 = await zip.getEntry('test.txt');
+    expect(Buffer.isBuffer(buf1)).toBe(true);
+    expect((buf1 as Buffer).toString()).toBe('hello world');
+
+    // By regex
+    const buf2 = await zip.getEntry(/foo.bar/);
+    expect(Buffer.isBuffer(buf2)).toBe(true);
+    expect((buf2 as Buffer).toString()).toBe('baz');
+  });
+
+  test('getEntry and getEntries handle blob return type', async () => {
+    const zipPath = path.join(tempRoot, 'app.zip');
+    await writeZip(zipPath, {
+      'test.txt': 'hello world',
+    });
+
+    const zip = new Zip(zipPath);
+
+    const blob1 = await zip.getEntry('test.txt', 'blob');
+    expect(blob1).toBeInstanceOf(Blob);
+    expect(await (blob1 as Blob).text()).toBe('hello world');
+
+    const buffers = await zip.getEntries(['test.txt'], 'blob');
+    expect(buffers['test.txt']).toBeInstanceOf(Blob);
+    expect(await (buffers['test.txt'] as Blob).text()).toBe('hello world');
+  });
+
+  test('getEntryFromHarmonyApp extracts matching file', async () => {
+    const zipPath = path.join(tempRoot, 'app.zip');
+    await writeZip(zipPath, {
+      'config.json': '{"harmony": true}',
+      'other.txt': 'ignore',
+    });
+
+    const zip = new Zip(zipPath);
+
+    const buf = await zip.getEntryFromHarmonyApp(/config.json/);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect((buf as Buffer).toString()).toBe('{"harmony": true}');
+  });
+
+  test('constructor resolves path for string input', () => {
+    const relPath = 'some/relative/path.zip';
+    const zip = new Zip(relPath);
+    expect(zip.file).toBe(path.resolve(relPath));
+  });
+
+  test('throws error when reading entries and file is not a string', async () => {
+    // Simulate a File object which is not a string
+    const mockFile = new Blob(['dummy']) as File;
+    const zip = new Zip(mockFile);
+
+    expect(zip.file).toBe(mockFile);
+
+    try {
+      await zip.getEntry('any');
+      expect(true).toBe(false); // Should not reach here
+    } catch (e: any) {
+      expect(e.message).toBe('Param error: [file] must be file path in Node.');
+    }
+
+    try {
+      await zip.getEntries(['any']);
+      expect(true).toBe(false); // Should not reach here
+    } catch (e: any) {
+      expect(e.message).toBe('Param error: [file] must be file path in Node.');
+    }
+
+    // getEntryFromHarmonyApp catches the error and logs to console, returning undefined
+    const originalError = console.error;
+    let consoleOutput = '';
+    console.error = (_msg: string, err: any) => {
+      consoleOutput += err.message;
+    };
+    const res = await zip.getEntryFromHarmonyApp(/any/);
+    console.error = originalError;
+
+    expect(res).toBeUndefined();
+    expect(consoleOutput).toBe(
+      'Param error: [file] must be file path in Node.',
+    );
+  });
 });


### PR DESCRIPTION
🎯 **What:** The `Zip` class in `src/utils/app-info-parser/zip.ts` lacked comprehensive test coverage. While `getEntries` was partially covered, other methods and error cases were not.
📊 **Coverage:** Added tests for:
  * `getEntry` (buffer and blob types)
  * `getEntries` (blob type)
  * `getEntryFromHarmonyApp`
  * Proper constructor behavior (resolving path string)
  * Error handling when an invalid object (like a File instead of a path) is provided.
✨ **Result:** Increased code reliability and safety for refactoring within the `Zip` utility class by ensuring its methods function according to specification.

---
*PR created automatically by Jules for task [12866233695446301254](https://jules.google.com/task/12866233695446301254) started by @sunnylqm*