### PR TITLE
🔒 Fix command injection in install command

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -15,7 +15,6 @@ export const installCommands = {
     spawnSync(installCommand.command, installCommand.args, {
       cwd: cliDir,
       stdio: 'inherit',
-      shell: true,
     });
   },
 };


### PR DESCRIPTION
🎯 What: Removed the shell: true option from spawnSync in src/install.ts.
⚠️ Risk: Using shell: true with arguments derived from external inputs (like package manager arguments) could allow an attacker to inject arbitrary shell commands if the inputs are not perfectly sanitized.
🛡️ Solution: Removing shell: true executes the command directly without a shell interpreter, making it immune to shell injection techniques.

---
*PR created automatically by Jules for task [3181168032761039279](https://jules.google.com/task/3181168032761039279) started by @sunnylqm*