### PR TITLE
🔒 Fix insecure predictable temporary file creation

### DIFF
--- a/src/utils/app-info-parser/aab.ts
+++ b/src/utils/app-info-parser/aab.ts
@@ -57,8 +57,8 @@ export class AabParser extends Zip {
       });
 
     // Create a temp file for the .apks output
-    const tempDir = os.tmpdir();
-    const tempApksPath = path.join(tempDir, `temp-${Date.now()}.apks`);
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bundletool-'));
+    const tempApksPath = path.join(tempDir, 'output.apks');
 
     const needsNpxDownload = async () => {
       try {
@@ -155,8 +155,8 @@ export class AabParser extends Zip {
       });
     } finally {
       // Cleanup
-      if (await fs.pathExists(tempApksPath)) {
-        await fs.remove(tempApksPath);
+      if (await fs.pathExists(tempDir)) {
+        await fs.remove(tempDir);
       }
     }
   }


### PR DESCRIPTION
🎯 **What:** Fixed an insecure predictable temporary file creation in `AabParser.extractApk` where `Date.now()` was used to generate a filename in a shared temporary directory.
⚠️ **Risk:** A predictable temporary file name in a shared directory like `os.tmpdir()` allows for a local symlink attack, potentially leading to unauthorized file overwrites or privilege escalation if the application is run with higher privileges.
🛡️ **Solution:** Replaced the predictable filename generation with `fs.mkdtemp`, which creates a securely randomized temporary directory within `os.tmpdir()`. The temporary file is now created inside this secure directory, and the cleanup logic removes the entire temporary directory.

---
*PR created automatically by Jules for task [9732741395195757645](https://jules.google.com/task/9732741395195757645) started by @sunnylqm*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of app package extraction by handling temporary files more safely, reducing the chance of leftover artifacts during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->