### PR TITLE
Document global CLI installation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,25 @@ A React Native Update command line tool for bundling, uploading native packages,
 ## Installation
 
 ```bash
-npm install react-native-update-cli
+npm install -g react-native-update-cli
 ```
+
+The command-line tool is installed globally. Invoke `pushy` or `cresc` directly; do not use a project-local CLI or prefix commands with `npx`.
 
 ## Basic Usage
 
 ```bash
-npx pushy help
-npx pushy list
+pushy help
+pushy list
 
-npx pushy bundle --platform ios
-npx pushy publish --platform ios --name 1.0.0
-npx pushy uploadIpa ./app.ipa
+pushy bundle --platform ios
+pushy publish --platform ios --name 1.0.0
+pushy uploadIpa ./app.ipa
 ```
 
 ## Programmatic Usage
+
+The Provider API is a library integration, separate from the globally installed CLI. Add the package to build-tool dependencies only when importing this API; command-line usage continues to use the global `pushy` / `cresc` binaries.
 
 ```typescript
 import { CLIProviderImpl } from 'react-native-update-cli';
@@ -147,7 +151,7 @@ sentry-cli sourcemaps upload --debug-id-reference
 For older self-hosted Sentry versions or older `@sentry/cli` versions without Debug ID support, pass explicit legacy release/dist values:
 
 ```bash
-npx pushy bundle --platform android --name "4.1" --sentry-release "com.example@1.0.0+10+pushy:4.1" --sentry-dist "pushy:4.1"
+pushy bundle --platform android --name "4.1" --sentry-release "com.example@1.0.0+10+pushy:4.1" --sentry-dist "pushy:4.1"
 ```
 
 In legacy mode, the app runtime must report exactly the same Sentry `release` and `dist` values.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,21 +14,25 @@ React Native Update 命令行工具，用于打包、上传原生包、发布 OT
 ## 安装
 
 ```bash
-npm install react-native-update-cli
+npm install -g react-native-update-cli
 ```
+
+命令行工具始终全局安装，直接调用 `pushy` 或 `cresc`；不要使用项目本地 CLI，也不要给命令添加 `npx` 前缀。
 
 ## 基础用法
 
 ```bash
-npx pushy help
-npx pushy list
+pushy help
+pushy list
 
-npx pushy bundle --platform ios
-npx pushy publish --platform ios --name 1.0.0
-npx pushy uploadIpa ./app.ipa
+pushy bundle --platform ios
+pushy publish --platform ios --name 1.0.0
+pushy uploadIpa ./app.ipa
 ```
 
 ## 编程调用
+
+Provider API 属于库集成，与全局 CLI 分开。只有在代码中导入该 API 时才把包加入构建工具依赖；命令行仍然使用全局的 `pushy` / `cresc`。
 
 ```typescript
 import { CLIProviderImpl } from 'react-native-update-cli';
@@ -147,7 +151,7 @@ sentry-cli sourcemaps upload --debug-id-reference
 旧版 self-hosted Sentry 或旧版 `@sentry/cli` 不支持 Debug ID 时，可以显式指定 legacy release/dist：
 
 ```bash
-npx pushy bundle --platform android --name "4.1" --sentry-release "com.example@1.0.0+10+pushy:4.1" --sentry-dist "pushy:4.1"
+pushy bundle --platform android --name "4.1" --sentry-release "com.example@1.0.0+10+pushy:4.1" --sentry-dist "pushy:4.1"
 ```
 
 这种 legacy 模式要求 App 运行时上报到 Sentry 的 `release` 和 `dist` 与上传参数完全一致。


### PR DESCRIPTION
## What changed

- install react-native-update-cli globally in the English and Chinese READMEs
- invoke pushy/cresc directly instead of through npx in basic and Sentry examples
- clarify that the Provider API is a separate library integration while command-line usage stays global

## Why

The current examples implied a project-local CLI even though the supported command workflow uses the global binaries.

No command implementation or compatibility behavior changed.

## Validation

- verified both READMEs contain the global install command and direct CLI examples
- verified no npx pushy/cresc or local install examples remain
- git diff whitespace checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-update-cli/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789182431&installation_model_id=426977&pr_number=71&repository=reactnativecn%2Freact-native-update-cli&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-update-cli%2Fpull%2F71&signature=2e5a581b7bb68962fa31fa4e18228e8f2605db47ba8a7ab2b2feae1372bde36e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English and Chinese CLI setup instructions to use a global installation.
  * Revised command examples to invoke `pushy` and `cresc` directly instead of through `npx`.
  * Clarified that the Provider API is provided through a separate library integration.
  * Updated the legacy Sentry command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->